### PR TITLE
fix: Add missing import for deque in crop.py

### DIFF
--- a/frameshift/utils/crop.py
+++ b/frameshift/utils/crop.py
@@ -1,6 +1,7 @@
 """Functions for crop box computation and smoothing."""
 from typing import List, Tuple, Optional
 import numpy as np
+from collections import deque
 
 
 def union_boxes(boxes: List[Tuple[int, int, int, int]]) -> Optional[Tuple[int, int, int, int]]:


### PR DESCRIPTION
Resolves NameError: name 'deque' is not defined, which occurred because 'from collections import deque' was missing in frameshift/utils/crop.py where it's used by smooth_box_windowed.