### PR TITLE
fix: Add missing typing imports in crop.py

### DIFF
--- a/frameshift/utils/crop.py
+++ b/frameshift/utils/crop.py
@@ -1,5 +1,5 @@
 """Functions for crop box computation and smoothing."""
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Dict, Any # Added Dict, Any
 import numpy as np
 from collections import deque
 


### PR DESCRIPTION
Resolves NameError for Dict and Any in frameshift/utils/crop.py by ensuring they are correctly imported from the typing module.