### PR TITLE
refactor: Simplify to stationary mode and overhaul padding logic

### DIFF
--- a/frameshift/main.py
+++ b/frameshift/main.py
@@ -10,8 +10,7 @@ from scenedetect import open_video, SceneManager
 from scenedetect.detectors import ContentDetector
 
 from .utils.detection import Detector
-# Renamed smooth_box to smooth_box_legacy, new one is smooth_box_windowed
-from .utils.crop import union_boxes, smooth_box_legacy, smooth_box_windowed, compute_crop, calculate_weighted_interest_region
+from .utils.crop import union_boxes, compute_crop, calculate_weighted_interest_region
 from .weights_parser import parse_object_weights
 
 
@@ -78,18 +77,72 @@ def process_video(
     input_path: str,
     output_path: str,
     ratio: str,
-    mode: str = "tracking",
-    enable_padding: bool = False,
+    padding_style: str = "fill",
     blur_amount: int = 21,
     content_opacity: float = 1.0,
-    tracking_responsiveness: float = 0.2,
-    object_weights_map: Dict[str, float] = None, # Will be populated by parsed arg
-    smoothing_window_size: int = 5,
-    tracking_deadzone_center_px: int = 10,
-    tracking_deadzone_size_percent: float = 0.05,
+    object_weights_map: Dict[str, float] = None,
 ) -> None:
-    if object_weights_map is None: # Default if not passed (e.g. direct call)
+    if object_weights_map is None:
         object_weights_map = {'face': 1.0, 'person': 0.8, 'default': 0.5}
+    # La modalità è implicitamente 'stationary'
+
+    # Helper function for padding styles 'blur' and 'black'
+    # This could also be moved to utils/crop.py if preferred
+    def _apply_fit_padding(base_frame_template: np.ndarray, content_to_fit: np.ndarray,
+                           target_w: int, target_h: int, is_blur_bg: bool = False, blur_kernel_size: int = 21, original_frame_for_blur = None) -> np.ndarray:
+
+        output_frame = base_frame_template.copy() # Start with black or pre-blurred background
+
+        if content_to_fit.shape[0] == 0 or content_to_fit.shape[1] == 0:
+            return output_frame
+
+        content_h, content_w = content_to_fit.shape[:2]
+        if content_h == 0 or content_w == 0:
+            return output_frame
+
+        scale_h = target_h / content_h
+        scale_w = target_w / content_w
+        scale = min(scale_h, scale_w)
+
+        scaled_w = int(content_w * scale)
+        scaled_h = int(content_h * scale)
+
+        if scaled_w == 0 or scaled_h == 0:
+            return output_frame
+
+        resized_content = cv2.resize(content_to_fit, (scaled_w, scaled_h), interpolation=cv2.INTER_AREA)
+
+        pad_x = (target_w - scaled_w) // 2
+        pad_y = (target_h - scaled_h) // 2
+
+        dst_x_start = max(0, pad_x)
+        dst_y_start = max(0, pad_y)
+
+        copy_w = min(scaled_w, target_w - dst_x_start)
+        copy_h = min(scaled_h, target_h - dst_y_start)
+
+        src_x_start = 0
+        src_y_start = 0
+
+        if copy_w > 0 and copy_h > 0:
+            # Ensure the slice from resized_content is valid
+            src_slice_w = min(copy_w, resized_content.shape[1])
+            src_slice_h = min(copy_h, resized_content.shape[0])
+
+            # Ensure the destination slice is valid
+            dst_slice_w = min(copy_w, output_frame.shape[1] - dst_x_start)
+            dst_slice_h = min(copy_h, output_frame.shape[0] - dst_y_start)
+
+            # Final actual copy dimensions must match
+            final_copy_w = min(src_slice_w, dst_slice_w)
+            final_copy_h = min(src_slice_h, dst_slice_h)
+
+            if final_copy_w > 0 and final_copy_h > 0:
+                # Resize content to fit the exact calculated copy dimensions before placing
+                content_final_size = cv2.resize(resized_content, (final_copy_w, final_copy_h), interpolation=cv2.INTER_AREA)
+                output_frame[dst_y_start : dst_y_start + final_copy_h,
+                             dst_x_start : dst_x_start + final_copy_w] = content_final_size
+        return output_frame
 
     if ":" in ratio:
         w_str, h_str = ratio.split(':')
@@ -115,38 +168,28 @@ def process_video(
     out = cv2.VideoWriter(output_path, fourcc, fps, (out_w, out_h))
 
     frame_idx = 0
-    # prev_box is now prev_smoothed_crop_box, storing the output of the smoothing function
-    prev_smoothed_crop_box: Optional[np.ndarray] = None
-    # historical_raw_boxes stores raw (un-smoothed) boxes from compute_crop for windowed smoothing
-    historical_raw_boxes: deque = deque(maxlen=max(1, smoothing_window_size)) # maxlen must be > 0
-
-    # prev_box is used by stationary and panning modes to store scene-specific state
-    # For stationary, it's the fixed box for the scene.
-    # For panning, it's the starting box for the pan.
+    # prev_box è usato dalla modalità stationary per memorizzare il box fisso della scena.
     prev_box: Optional[np.ndarray] = None
-    pan_end: Optional[np.ndarray] = None # Specific to panning mode
 
     start = scene_bounds[0][0] # Start frame of the current scene
     current_scene_end = scene_bounds[0][1] # End frame of the current scene
     scene_iter = iter(scene_bounds)
-    _ = next(scene_iter) # Consuma la prima scena dall'iteratore, 'start' e 'current_scene_end' si riferiscono alla prima scena
+    _ = next(scene_iter) # Consuma la prima scena dall'iteratore
 
-    # Inizializzazione di prev_box per la prima scena se in modalità stazionaria
-    if mode == "stationary":
-        # print(f"DEBUG: Initializing prev_box for stationary mode for first scene ({start}-{current_scene_end})")
-        initial_crop_for_stationary = sample_crop(
-            input_path,
-            start,
-            current_scene_end,
-            detector,
-            width,
-            height,
-            aspect_ratio,
-            object_weights_map, # Passare i pesi
-        )
-        # sample_crop dovrebbe sempre restituire una tupla valida (x,y,w,h)
-        prev_box = np.array(initial_crop_for_stationary)
-        # print(f"DEBUG: Initial prev_box for stationary: {prev_box}")
+    # Inizializzazione di prev_box per la prima scena (modalità stationary implicita)
+    # print(f"DEBUG: Initializing prev_box for stationary mode for first scene ({start}-{current_scene_end})")
+    initial_crop_for_stationary = sample_crop(
+        input_path,
+        start,
+        current_scene_end,
+        detector,
+        width,
+        height,
+        aspect_ratio,
+        object_weights_map, # Passare i pesi
+    )
+    prev_box = np.array(initial_crop_for_stationary)
+    # print(f"DEBUG: Initial prev_box for stationary: {prev_box}")
 
     pbar = tqdm(total=int(cap.get(cv2.CAP_PROP_FRAME_COUNT)), desc="Processing")
     while True:
@@ -159,126 +202,26 @@ def process_video(
             except StopIteration:
                 current_scene_end = float('inf')
 
-            # Reset per stati dipendenti dalla scena
-            pan_end = None # Per panning
-            # 'prev_box' è usato da stationary e panning (come start_box)
-            # Viene ricalcolato sotto se mode == stationary o se mode == panning e prev_box è None
-            prev_box = None
-
-            if mode == "tracking":
-                historical_raw_boxes.clear()
-                prev_smoothed_crop_box = None
-
-            if mode == "stationary":
-                # Ricalcola il box fisso per la nuova scena usando 'start' (inizio della nuova scena)
-                prev_box = np.array(
-                    sample_crop(
-                        input_path,
-                        start,
-                        current_scene_end,
-                        detector,
-                        width,
-                        height,
-                        aspect_ratio,
-                        object_weights_map,
-                    )
+            # Ricalcola il box fisso per la nuova scena (modalità stationary implicita)
+            prev_box = np.array(
+                sample_crop(
+                    input_path,
+                    start,
+                    current_scene_end,
+                    detector,
+                    width,
+                    height,
+                    aspect_ratio,
+                    object_weights_map,
                 )
-
-        # Determinazione del crop_box per il frame corrente
-        if mode == "stationary":
-            # prev_box è stato calcolato all'inizio di process_video o al cambio di scena.
-            # Deve essere un np.ndarray valido qui.
-            if prev_box is None: # Fallback di sicurezza, non dovrebbe accadere
-                # print("ERROR: prev_box is None in stationary mode unexpectedly.")
-                crop_box = np.array([0,0,width,height]) # Fallback a full frame
-            else:
-                crop_box = prev_box
-        elif mode == "panning":
-            # prev_box qui funge da pan_start_box.
-            if prev_box is None:
-                scene_duration = current_scene_end - start
-                sample_window_len = min(max(30, scene_duration // 4), 150)
-
-                start_crop_sample_start_ts = start
-                start_crop_sample_end_ts = min(current_scene_end, start + sample_window_len)
-
-                end_crop_sample_start_ts = max(start, current_scene_end - sample_window_len)
-                end_crop_sample_end_ts = current_scene_end
-
-                if scene_duration < 2 * sample_window_len and scene_duration > 0 : # Scena corta, evita sovrapposizione eccessiva
-                    mid_point = start + scene_duration // 2
-                    start_crop_sample_end_ts = mid_point
-                    end_crop_sample_start_ts = mid_point
-
-                # Assicura che le finestre di campionamento siano valide (start < end)
-                if start_crop_sample_start_ts >= start_crop_sample_end_ts:
-                    start_crop_sample_end_ts = min(current_scene_end, start_crop_sample_start_ts + 1) if current_scene_end > start_crop_sample_start_ts else start_crop_sample_start_ts
-
-                if end_crop_sample_start_ts >= end_crop_sample_end_ts:
-                    end_crop_sample_start_ts = max(start, end_crop_sample_end_ts - 1) if start < end_crop_sample_end_ts else end_crop_sample_end_ts
-
-                # print(f"DEBUG Panning: Scene: {start}-{current_scene_end} (dur: {scene_duration}), frame_idx: {frame_idx}")
-                # print(f"DEBUG Panning: Start crop sample window: [{start_crop_sample_start_ts}, {start_crop_sample_end_ts})")
-                # print(f"DEBUG Panning: End crop sample window:   [{end_crop_sample_start_ts}, {end_crop_sample_end_ts})")
-
-                start_crop = sample_crop(input_path, start_crop_sample_start_ts, start_crop_sample_end_ts,
-                                         detector, width, height, aspect_ratio, object_weights_map) # Passare i pesi
-                end_crop = sample_crop(input_path, end_crop_sample_start_ts, end_crop_sample_end_ts,
-                                       detector, width, height, aspect_ratio, object_weights_map) # Passare i pesi
-                prev_box = np.array(start_crop)
-                pan_end = np.array(end_crop)
-
-            alpha = (frame_idx - start) / max(1, current_scene_end - start) if current_scene_end > start else 0
-            crop_box = (prev_box * (1 - alpha) + pan_end * alpha).astype(int)
-        elif mode == "tracking":
-            faces_detected, objects_detected = detector.detect(frame)
-            all_detections = faces_detected + objects_detected
-
-            interest_guide_box = calculate_weighted_interest_region(
-                all_detections, object_weights_map, width, height
             )
 
-            current_raw_crop_tuple = compute_crop(interest_guide_box, width, height, aspect_ratio)
-            current_raw_crop_arr = np.array(current_raw_crop_tuple) # (x,y,w,h)
-
-            should_move = True
-            if prev_smoothed_crop_box is not None:
-                prev_x, prev_y, prev_w, prev_h = prev_smoothed_crop_box
-                prev_cx = prev_x + prev_w / 2.0
-                prev_cy = prev_y + prev_h / 2.0
-
-                curr_x, curr_y, curr_w, curr_h = current_raw_crop_arr
-                curr_cx = curr_x + curr_w / 2.0
-                curr_cy = curr_y + curr_h / 2.0
-
-                center_diff = np.sqrt((curr_cx - prev_cx)**2 + (curr_cy - prev_cy)**2)
-
-                size_diff_w = abs(curr_w - prev_w) / max(1, float(prev_w)) if prev_w > 0 else (0 if curr_w == 0 else 1.0)
-                size_diff_h = abs(curr_h - prev_h) / max(1, float(prev_h)) if prev_h > 0 else (0 if curr_h == 0 else 1.0)
-
-                if (center_diff < tracking_deadzone_center_px and
-                    size_diff_w < tracking_deadzone_size_percent and
-                    size_diff_h < tracking_deadzone_size_percent):
-                    should_move = False
-
-            if should_move:
-                smoothed_box_arr = smooth_box_windowed(
-                    historical_raw_boxes,
-                    current_raw_crop_arr,
-                    tracking_responsiveness,
-                    prev_smoothed_crop_box
-                )
-                prev_smoothed_crop_box = smoothed_box_arr # Aggiorna il box smussato per il prossimo frame
-                crop_box = smoothed_box_arr
-            else: # Non muovere la camera
-                crop_box = prev_smoothed_crop_box # Usa l'ultimo box smussato
-                # prev_smoothed_crop_box rimane lo stesso, la camera non si è mossa
-
-            # Aggiorna sempre lo storico dei box grezzi
-            historical_raw_boxes.append(current_raw_crop_arr)
-
-        else: # Should not happen (se mode non è stationary, panning, o tracking)
-            crop_box = np.array([0,0,width,height])
+        # Determinazione del crop_box per il frame corrente (sempre stationary)
+        if prev_box is None: # Fallback di sicurezza, non dovrebbe accadere con la logica sopra
+            # print("ERROR: prev_box is None in stationary mode unexpectedly.")
+            crop_box = np.array([0,0,width,height]) # Fallback a full frame
+        else:
+            crop_box = prev_box
 
 
         # Fallback se crop_box è None (non dovrebbe accadere con le correzioni precedenti, ma per sicurezza)
@@ -299,63 +242,23 @@ def process_video(
 
         cropped_content = frame[y1_crop:y1_crop+ch_crop, x1_crop:x1_crop+cw_crop]
 
-        final_frame_output = np.zeros((out_h, out_w, 3), dtype=np.uint8)
+        # final_frame_output sarà determinato dal padding_style
 
-        if enable_padding:
-            blurred_background = cv2.GaussianBlur(cv2.resize(frame, (out_w, out_h), interpolation=cv2.INTER_AREA), (0,0), blur_amount)
+        if padding_style == 'blur':
+            # Crea sfondo sfocato
+            background_for_blur = cv2.GaussianBlur(cv2.resize(frame, (out_w, out_h), interpolation=cv2.INTER_AREA), (0,0), blur_amount)
+            final_frame_output = _apply_fit_padding(background_for_blur, cropped_content, out_w, out_h)
 
-            content_h, content_w = cropped_content.shape[:2]
-            if content_h == 0 or content_w == 0:
-                # Se il crop è vuoto, il contenuto ridimensionato riempirà l'output come nero (o sfondo sfocato se opacità < 1)
-                resized_content_for_padding = np.zeros((out_h, out_w, 3), dtype=np.uint8)
-                final_content_w, final_content_h = out_w, out_h
-            else:
-                scale_h = out_h / content_h
-                scale_w = out_w / content_w
-                scale = min(scale_h, scale_w)
-                final_content_w = int(content_w * scale)
-                final_content_h = int(content_h * scale)
-                resized_content_for_padding = cv2.resize(cropped_content, (final_content_w, final_content_h), interpolation=cv2.INTER_AREA)
+        elif padding_style == 'black':
+            background_black = np.zeros((out_h, out_w, 3), dtype=np.uint8) # Sfondo nero
+            final_frame_output = _apply_fit_padding(background_black, cropped_content, out_w, out_h)
 
-            pad_x = (out_w - final_content_w) // 2
-            pad_y = (out_h - final_content_h) // 2
-
-            final_frame_output = blurred_background.copy()
-
-            # Prepara la porzione di sfondo su cui il contenuto verrà sovrapposto
-            # Assicurati che le fette non siano negative o fuori dai limiti se final_content_w/h sono più grandi di out_w/h (non dovrebbe succedere con min(scale))
-            bg_slice_y_start = max(0, pad_y)
-            bg_slice_y_end = min(out_h, pad_y + final_content_h)
-            bg_slice_x_start = max(0, pad_x)
-            bg_slice_x_end = min(out_w, pad_x + final_content_w)
-
-            content_slice_h = bg_slice_y_end - bg_slice_y_start
-            content_slice_w = bg_slice_x_end - bg_slice_x_start
-
-            if content_slice_h > 0 and content_slice_w > 0: # Solo se l'area di sovrapposizione è valida
-                # Estrai la porzione di sfondo corrispondente al contenuto ridimensionato
-                center_of_background = blurred_background[bg_slice_y_start:bg_slice_y_end, bg_slice_x_start:bg_slice_x_end]
-
-                # Adatta resized_content_for_padding se le dimensioni della fetta sono diverse (ad es. a causa di arrotondamenti/limiti)
-                actual_content_to_blend = cv2.resize(resized_content_for_padding, (content_slice_w, content_slice_h), interpolation=cv2.INTER_AREA)
-
-                if content_opacity < 1.0:
-                    if center_of_background.shape[:2] == actual_content_to_blend.shape[:2]:
-                        blended_content = cv2.addWeighted(actual_content_to_blend, content_opacity, center_of_background, 1 - content_opacity, 0)
-                        final_frame_output[bg_slice_y_start:bg_slice_y_end, bg_slice_x_start:bg_slice_x_end] = blended_content
-                    else: # Fallback se le dimensioni non corrispondono (non dovrebbe accadere con la logica sopra)
-                        final_frame_output[bg_slice_y_start:bg_slice_y_end, bg_slice_x_start:bg_slice_x_end] = actual_content_to_blend
-                else:
-                    final_frame_output[bg_slice_y_start:bg_slice_y_end, bg_slice_x_start:bg_slice_x_end] = actual_content_to_blend
-            # Se content_slice_h/w è 0, final_frame_output rimane lo sfondo sfocato (corretto)
-
-        else: # Modalità Fill/Pan & Scan: riempie il frame di output, tagliando se necessario.
-            final_frame_output = np.zeros((out_h, out_w, 3), dtype=np.uint8) # Inizia con un frame nero
-
+        elif padding_style == 'fill': # Default: Fill / Pan & Scan
+            # Logica per FILL / PAN & SCAN
+            final_frame_output = np.zeros((out_h, out_w, 3), dtype=np.uint8) # Inizia nero, ma verrà riempito
             if cropped_content.shape[0] > 0 and cropped_content.shape[1] > 0:
                 content_h, content_w = cropped_content.shape[:2]
-                if content_h > 0 and content_w > 0: # Procedi solo se le dimensioni del contenuto sono valide
-                    # Scala per riempire (Pan & Scan)
+                if content_h > 0 and content_w > 0:
                     scale_h_fill = out_h / content_h
                     scale_w_fill = out_w / content_w
                     scale_fill = max(scale_h_fill, scale_w_fill)
@@ -366,58 +269,57 @@ def process_video(
                     if scaled_content_fill_w > 0 and scaled_content_fill_h > 0:
                         content_to_process = cv2.resize(cropped_content, (scaled_content_fill_w, scaled_content_fill_h), interpolation=cv2.INTER_AREA)
 
-                        # Calcola gli offset per centrare l'immagine scalata e determinare la regione da copiare
                         src_x = (scaled_content_fill_w - out_w) // 2
                         src_y = (scaled_content_fill_h - out_h) // 2
+                        dst_x = 0; dst_y = 0
+                        copy_width = out_w; copy_height = out_h
 
-                        dst_x = 0
-                        dst_y = 0
-
-                        copy_width = out_w
-                        copy_height = out_h
-
-                        # Se l'immagine scalata è più stretta dell'output (non dovrebbe succedere con max scale, ma per sicurezza)
                         if scaled_content_fill_w < out_w:
-                            dst_x = (out_w - scaled_content_fill_w) // 2
-                            src_x = 0
-                            copy_width = scaled_content_fill_w
-
-                        # Se l'immagine scalata è meno alta dell'output
+                            dst_x = (out_w - scaled_content_fill_w) // 2; src_x = 0; copy_width = scaled_content_fill_w
                         if scaled_content_fill_h < out_h:
-                            dst_y = (out_h - scaled_content_fill_h) // 2
-                            src_y = 0
-                            copy_height = scaled_content_fill_h
+                            dst_y = (out_h - scaled_content_fill_h) // 2; src_y = 0; copy_height = scaled_content_fill_h
 
-                        # Assicura che le coordinate sorgente siano valide e non negative
-                        src_x = max(0, src_x)
-                        src_y = max(0, src_y)
+                        src_x = max(0, src_x); src_y = max(0, src_y)
 
-                        # Assicura che le dimensioni da copiare non eccedano la sorgente disponibile
-                        actual_copy_w = min(copy_width, content_to_process.shape[1] - src_x)
-                        actual_copy_h = min(copy_height, content_to_process.shape[0] - src_y)
-
-                        # Assicura che le dimensioni da copiare non eccedano la destinazione disponibile
-                        actual_copy_w = min(actual_copy_w, out_w - dst_x)
-                        actual_copy_h = min(actual_copy_h, out_h - dst_y)
-
+                        actual_copy_w = min(copy_width, content_to_process.shape[1] - src_x, out_w - dst_x)
+                        actual_copy_h = min(copy_height, content_to_process.shape[0] - src_y, out_h - dst_y)
 
                         if actual_copy_w > 0 and actual_copy_h > 0:
                             src_slice = content_to_process[src_y : src_y + actual_copy_h, src_x : src_x + actual_copy_w]
-                            # Se lo slice sorgente non ha le dimensioni esatte di actual_copy_w/h (improbabile qui)
-                            # o se actual_copy_w/h non sono uguali a out_w/h (possibile se src_x/y erano <0)
-                            # potremmo aver bisogno di un resize finale per la porzione di destinazione.
-                            # Ma la logica di dst_x, dst_y, actual_copy_w/h dovrebbe definire una fetta valida per final_frame_output
-                            if src_slice.shape[0] == actual_copy_h and src_slice.shape[1] == actual_copy_w :
+                            if src_slice.shape[0] == actual_copy_h and src_slice.shape[1] == actual_copy_w:
                                 final_frame_output[dst_y : dst_y + actual_copy_h, dst_x : dst_x + actual_copy_w] = src_slice
-                            # else:
-                                # print(f"WARN: Mismatch in Pan&Scan copy. Src_slice: {src_slice.shape}, Target area: ({actual_copy_h},{actual_copy_w})")
-                                # Potrebbe essere necessario un resize di src_slice a (actual_copy_w, actual_copy_h) prima di assegnare.
-                                # Per ora, ci si aspetta che le dimensioni corrispondano.
             # Se cropped_content era vuoto o le sue dimensioni scalate non valide, final_frame_output rimane nero.
+        else: # Stile di padding non riconosciuto, fallback a nero (o fill)
+            print(f"Warning: Unknown padding_style '{padding_style}'. Defaulting to 'fill'.")
+            # Copia-incolla della logica 'fill' per sicurezza come fallback
+            final_frame_output = np.zeros((out_h, out_w, 3), dtype=np.uint8)
+            if cropped_content.shape[0] > 0 and cropped_content.shape[1] > 0:
+                content_h, content_w = cropped_content.shape[:2]
+                if content_h > 0 and content_w > 0:
+                    scale_h_fill = out_h / content_h; scale_w_fill = out_w / content_w
+                    scale_fill = max(scale_h_fill, scale_w_fill)
+                    scaled_content_fill_w = int(content_w * scale_fill); scaled_content_fill_h = int(content_h * scale_fill)
+                    if scaled_content_fill_w > 0 and scaled_content_fill_h > 0:
+                        content_to_process = cv2.resize(cropped_content, (scaled_content_fill_w, scaled_content_fill_h), interpolation=cv2.INTER_AREA)
+                        src_x = (scaled_content_fill_w - out_w) // 2; src_y = (scaled_content_fill_h - out_h) // 2
+                        dst_x = 0; dst_y = 0
+                        copy_width = out_w; copy_height = out_h
+                        if scaled_content_fill_w < out_w: dst_x = (out_w - scaled_content_fill_w) // 2; src_x = 0; copy_width = scaled_content_fill_w
+                        if scaled_content_fill_h < out_h: dst_y = (out_h - scaled_content_fill_h) // 2; src_y = 0; copy_height = scaled_content_fill_h
+                        src_x = max(0, src_x); src_y = max(0, src_y)
+                        actual_copy_w = min(copy_width, content_to_process.shape[1] - src_x, out_w - dst_x)
+                        actual_copy_h = min(copy_height, content_to_process.shape[0] - src_y, out_h - dst_y)
+                        if actual_copy_w > 0 and actual_copy_h > 0:
+                            src_slice = content_to_process[src_y : src_y + actual_copy_h, src_x : src_x + actual_copy_w]
+                            if src_slice.shape[0] == actual_copy_h and src_slice.shape[1] == actual_copy_w:
+                                final_frame_output[dst_y : dst_y + actual_copy_h, dst_x : dst_x + actual_copy_w] = src_slice
 
-            if content_opacity < 1.0:
-                full_frame_blur_bg = cv2.GaussianBlur(cv2.resize(frame, (out_w, out_h), interpolation=cv2.INTER_AREA), (0,0), blur_amount)
-                final_frame_output = cv2.addWeighted(final_frame_output, content_opacity, full_frame_blur_bg, 1 - content_opacity, 0)
+        # Applica l'opacità generale se content_opacity < 1.0
+        # Questa logica si applica dopo che final_frame_output è stato costruito (con contenuto e padding/fill)
+        if content_opacity < 1.0:
+            # Lo sfondo per l'opacità è sempre il frame originale sfocato e ridimensionato a output
+            full_frame_blur_bg_for_opacity = cv2.GaussianBlur(cv2.resize(frame, (out_w, out_h), interpolation=cv2.INTER_AREA), (0,0), blur_amount)
+            final_frame_output = cv2.addWeighted(final_frame_output, content_opacity, full_frame_blur_bg_for_opacity, 1 - content_opacity, 0)
 
         out.write(final_frame_output)
 
@@ -429,26 +331,30 @@ def process_video(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="FrameShift auto reframing tool")
+    parser = argparse.ArgumentParser(description="FrameShift auto reframing tool. Default mode is 'stationary'.")
     parser.add_argument("input", help="Input file or directory")
     parser.add_argument("output", help="Output file or directory")
     parser.add_argument("--ratio", default="9/16", help="Target aspect ratio (e.g., 9/16)")
-    parser.add_argument("--mode", choices=["tracking", "stationary", "panning"], default="tracking",
-                        help="Cropping strategy")
-    parser.add_argument("--enable_padding", action="store_true", help="Enable letterbox/pillarbox padding with blurred background. Uses --blur_amount and --content_opacity.")
-    parser.add_argument("--blur_amount", type=int, default=21, help="Blur kernel size for padding background or full overlay background.")
-    parser.add_argument("--content_opacity", type=float, default=1.0, help="Opacity of the main content. If < 1.0, content is blended with the background (either bars or full frame blur).")
-    parser.add_argument("--tracking_responsiveness", type=float, default=0.2, help="For 'tracking' mode: how responsive the crop is to the current detected box (0.0-1.0). Lower values mean more smoothing. Default: 0.2")
+    parser.add_argument(
+        "--padding_style",
+        type=str,
+        default="fill",
+        choices=['fill', 'black', 'blur'],
+        help="Padding style. 'fill': Pan & Scan, content fills frame (default). "
+             "'black': Fit content, use black bars. "
+             "'blur': Fit content, use blurred background bars."
+    )
+    parser.add_argument("--blur_amount", type=int, default=21, help="Blur kernel size for 'blur' padding_style.")
+    parser.add_argument("--content_opacity", type=float, default=1.0, help="Opacity of the main content. If < 1.0, content is blended with the background.")
+    # Nota: l'argomento --enable_padding è stato rimosso. Usare --padding_style.
     parser.add_argument(
         "--object_weights",
         type=str,
         default="face:1.0,person:0.8,default:0.5", # Default weights
         help="Comma-separated string of 'label:weight' pairs (e.g., \"face:1.0,person:0.8,default:0.5\"). "
-             "Assigns importance weights to detected object classes. 'default' is used for unspecified classes."
+             "Assigns importance weights to detected object classes for stationary mode. 'default' is used for unspecified classes."
     )
-    parser.add_argument("--smoothing_window_size", type=int, default=5, help="For 'tracking' mode: number of previous frames to consider for smoothing camera motion (e.g., 3-10). Default: 5.")
-    parser.add_argument("--tracking_deadzone_center_px", type=int, default=20, help="Tracking mode: min pixel change in detected interest center to trigger camera movement. Default: 20.")
-    parser.add_argument("--tracking_deadzone_size_percent", type=float, default=0.10, help="Tracking mode: min percentage change (0.0-1.0) in detected interest size to trigger camera movement/zoom. Default: 0.10 (10%).")
+    # Smoothing/deadzone arguments are removed as they were tracking specific
     parser.add_argument("--batch", action="store_true", help="Process all videos in input directory")
 
     args = parser.parse_args()
@@ -464,20 +370,14 @@ def main() -> None:
             if vid.suffix.lower() not in {".mp4", ".mov", ".mkv", ".avi"}:
                 continue
             out_path = out_dir / f"{vid.stem}_reframed.mp4"
-            process_video(str(vid), str(out_path), args.ratio, args.mode,
-                          args.enable_padding, args.blur_amount, args.content_opacity,
-                          args.tracking_responsiveness, object_weights_map=parsed_weights,
-                          smoothing_window_size=args.smoothing_window_size,
-                          tracking_deadzone_center_px=args.tracking_deadzone_center_px,
-                          tracking_deadzone_size_percent=args.tracking_deadzone_size_percent)
+            process_video(str(vid), str(out_path), args.ratio,
+                          padding_style=args.padding_style, blur_amount=args.blur_amount,
+                          content_opacity=args.content_opacity, object_weights_map=parsed_weights)
     else:
         parsed_weights = parse_object_weights(args.object_weights)
-        process_video(args.input, args.output, args.ratio, args.mode,
-                      args.enable_padding, args.blur_amount, args.content_opacity,
-                      args.tracking_responsiveness, object_weights_map=parsed_weights,
-                      smoothing_window_size=args.smoothing_window_size,
-                      tracking_deadzone_center_px=args.tracking_deadzone_center_px,
-                      tracking_deadzone_size_percent=args.tracking_deadzone_size_percent)
+        process_video(args.input, args.output, args.ratio,
+                      padding_style=args.padding_style, blur_amount=args.blur_amount,
+                      content_opacity=args.content_opacity, object_weights_map=parsed_weights)
 
 
 if __name__ == "__main__":

--- a/frameshift/utils/crop.py
+++ b/frameshift/utils/crop.py
@@ -1,7 +1,7 @@
 """Functions for crop box computation and smoothing."""
-from typing import List, Tuple, Optional, Dict, Any # Added Dict, Any
+from typing import List, Tuple, Optional, Dict, Any
 import numpy as np
-from collections import deque
+# from collections import deque # No longer needed after removing smooth_box_windowed
 
 
 def union_boxes(boxes: List[Tuple[int, int, int, int]]) -> Optional[Tuple[int, int, int, int]]:
@@ -16,37 +16,8 @@ def smooth_box(prev_box: Optional[np.ndarray], curr_box: np.ndarray, factor: flo
         return curr_box
     return (prev_box * (1 - factor) + curr_box * factor).astype(int)
 
-# Renaming old smooth_box
-smooth_box_legacy = smooth_box
 
-def smooth_box_windowed(
-    historical_raw_boxes: deque, # Deque of np.ndarray [(x,y,w,h), ...], does NOT include current_raw_box
-    current_raw_box: np.ndarray, # np.ndarray [x,y,w,h] - current un-smoothed box from compute_crop
-    responsiveness: float,       # How much weight to give the current_raw_box (0.0 to 1.0)
-    prev_smoothed_box: Optional[np.ndarray] # Smoothed box from the previous frame
-) -> np.ndarray:
-    """
-    Smooths the current_raw_box based on a historical window of raw boxes and the previous smoothed box.
-    Boxes are in (x, y, width, height) format.
-    """
-    # If no history and no previous smoothed box (very first frame of tracking), return current raw box.
-    if not historical_raw_boxes and prev_smoothed_box is None:
-        return current_raw_box
-
-    # If history is empty but there's a prev_smoothed_box (e.g., first few frames of tracking),
-    # use legacy smoothing logic between prev_smoothed and current_raw.
-    if not historical_raw_boxes:
-        return (prev_smoothed_box * (1 - responsiveness) + current_raw_box * responsiveness).astype(int)
-
-    # Calculate the mean of the boxes in the historical window
-    # These are raw (un-smoothed) boxes from previous frames.
-    historical_mean_box = np.mean(list(historical_raw_boxes), axis=0)
-
-    # Interpolate between the historical mean and the current raw box
-    smoothed_box = (historical_mean_box * (1 - responsiveness) + current_raw_box * responsiveness).astype(int)
-
-    return smoothed_box
-
+# smooth_box_legacy and smooth_box_windowed removed as they were specific to tracking mode.
 
 def compute_crop(box: Tuple[int, int, int, int], frame_w: int, frame_h: int, aspect_ratio: float) -> Tuple[int, int, int, int]:
     x1, y1, x2, y2 = box


### PR DESCRIPTION
- Core Refactoring:
  - Removed 'tracking' and 'panning' modes and their specific CLI arguments (--mode, --tracking_responsiveness, --smoothing_window_size, --tracking_deadzone_center_px, --tracking_deadzone_size_percent).
  - FrameShift now operates implicitly in 'stationary' mode, where a fixed optimal crop is determined for each scene.
  - Removed unused smoothing functions (smooth_box_legacy, smooth_box_windowed) from utils/crop.py and associated variables from process_video.

- Padding System Overhaul:
  - Replaced boolean `--enable_padding` with a new string argument `--padding_style` with choices:
    - `fill` (Default): Implements Pan & Scan. The cropped content is scaled to completely fill the output frame, trimming excess. No bars are visible.
    - `black`: Fits the cropped content within the output frame, adding black bars if necessary to maintain aspect ratio.
    - `blur`: Fits the cropped content, using a blurred version of the original frame for any necessary padding bars.
  - Implemented a helper function `_apply_fit_padding` in `process_video` to handle 'black' and 'blur' padding styles robustly.
  - The existing `--blur_amount` argument is now used by `padding_style='blur'`.

- Documentation:
  - Updated README.md extensively to reflect the single 'stationary' mode operation and the new `--padding_style` argument and its behaviors.
  - Removed documentation for obsolete arguments and modes.
  - Updated usage examples.