### PR TITLE
feat: Allow configurable interpolation for video resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Enhancements could include automatic selection of reframing strategies (like dyn
     *   Accepts names: `black`, `white`, `red`, `green`, `blue`, `yellow`, `cyan`, `magenta`.
     *   Accepts RGB tuple as string: `"(R,G,B)"` (e.g., `"(255,0,0)"` for red).
 *   `--output_height H`: (Default: `1080`, integer) Target height for the output video in pixels (e.g., 720, 1080, 1280, 1920). The width will be calculated automatically based on the target aspect ratio specified by `--ratio`. This allows control over the final output resolution.
+*   `--interpolation METHOD`: (Default: `lanczos`) Specifies the interpolation algorithm used for resizing video frames.
+    *   Choices: `nearest`, `linear`, `cubic`, `area`, `lanczos`.
+    *   `lanczos` (Lanczos over 8x8 neighborhood) or `cubic` are generally recommended for upscaling (enlarging images) as they can produce sharper results.
+    *   `area` is often best for downscaling (shrinking images).
+    *   `linear` is faster but might be less sharp than `cubic` or `lanczos`.
+    *   `nearest` is the fastest but produces blocky results, usually not recommended for video.
 *   `--content_opacity O`: (Default: `1.0`) Opacity of the main video content (0.0-1.0). If < 1.0, the content (including any padding) is blended with a blurred version of the full original frame.
 *   `--object_weights "label:w,..."`: (Default: `"face:1.0,person:0.8,default:0.5"`) Comma-separated `label:weight` pairs for object importance (e.g., `face:1.0,person:0.8`).
 *   `--batch`: (Flag) Process all videos in the input directory.


### PR DESCRIPTION
- Introduces a new command-line argument `--interpolation` (default: "lanczos") with choices: 'nearest', 'linear', 'cubic', 'area', 'lanczos'.
- This allows the user to select the OpenCV interpolation algorithm used for all significant resizing operations on video frames, including:
  - Scaling of the main cropped content (for 'fill' or 'fit' padding styles).
  - Resizing of the original frame for generating blurred backgrounds (for 'blur' padding or for the content opacity effect).
- Added a helper function `get_cv2_interpolation_flag` to map string names to OpenCV integer flags.
- `process_video` function signature and its calls updated to pass the selected interpolation flag.
- Updated README.md to document the new `--interpolation` argument and provide guidance on choosing an appropriate method.