### PR TITLE
refactor: Use local yolov11n-face model, improve test suite, optimize…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ FrameShift automatically reframes videos, using a stationary (fixed) crop for ea
    ```bash
    python -m frameshift.main my_video.mp4 test_run_output.mp4 --ratio 16:9 --test
    ```
-   *(Check `test_run_output_test_outputs/` directory and `test_run_output_test_suite.log` or similar for results.)*
+   *(Check `test_run_output_test_outputs/` directory and `test_run_output_test_suite.log` or similar for results. If an error occurs in one test scenario, the suite will log it and continue to the next.)*
 
 ## How FrameShift Works (Inspired by Google AutoFlip)
 
@@ -78,8 +78,8 @@ FrameShift intelligently reframes videos using a **stationary (fixed) crop per s
 
 1.  **Scene Detection:** Divides the video into scenes using PySceneDetect.
 2.  **Content Analysis:**
-    *   **Faces:** Primarily detected using a specialized YOLOv8 model from Hugging Face (`arnabdhar/YOLOv8-Face-Detection`). MediaPipe is used as a fallback if the YOLO face model fails to load or during its initial download.
-    *   **Other Objects:** Detected using the general-purpose YOLOv8n model. This step is performed *only if* you specify weights for object classes other than 'face' in the `--object_weights` argument. This optimizes performance when only face-centric reframing is needed.
+    *   **Faces:** The script attempts to load a specialized YOLO model for face detection, `yolov11n-face.pt` (expected to be available locally where the script or YOLO can find it, e.g., current working directory). If this model is not found or fails to load, MediaPipe's face detection is used as a fallback.
+    *   **Other Objects:** Detected using the general-purpose YOLOv8n model (which Ultralytics downloads automatically if not present). This object detection step is performed *only if* you specify weights for object classes other than 'face' (and 'default') with a weight greater than 0 in the `--object_weights` argument. This optimizes performance when only face-centric reframing is needed.
     *   The importance of all detected elements in guiding the crop is determined by the `--object_weights` argument.
 3.  **Optimal Stationary Crop:** For each scene, calculates a fixed crop window that best frames the weighted area of interest at the target aspect ratio.
 4.  **Output Generation (Cropping/Padding):**


### PR DESCRIPTION
… model loading

- Face Detection Model:
  - Detector now attempts to load "yolov11n-face.pt" directly. Users need to ensure this model file is available locally.
  - MediaPipe is used as a fallback if "yolov11n-face.pt" fails to load.
  - Removed automatic download from Hugging Face for the face model to simplify. Ultralytics' YOLO("yolov8n.pt") still handles its own download.

- Test Suite Enhancements:
  - Made the test suite in `run_test_suite` more robust by wrapping the processing of each test scenario in a try-except block. Errors in one scenario are logged, and the suite continues.

- Model Loading Optimization:
  - The `Detector` class (which loads YOLO and MediaPipe models) is now instantiated only once in `main()` and the instance is passed down to `process_video` and `sample_crop`.
  - This significantly speeds up batch processing and the test suite by avoiding repeated model loading.

- Bug Fix:
  - Corrected a NameError in `process_video` related to `blur_intensity_0_10` ensuring consistent use of `blur_amount_param`.

- Documentation:
  - Updated README.md to reflect the new face detection model behavior and test suite error handling.